### PR TITLE
Add [install] section to hyprpolkitagent.service

### DIFF
--- a/assets/hyprpolkitagent-service.in
+++ b/assets/hyprpolkitagent-service.in
@@ -10,5 +10,5 @@ Slice=session.slice
 TimeoutStopSec=5sec
 Restart=on-failure
 
- [Install]
- WantedBy=graphical-session.target
+[Install]
+WantedBy=graphical-session.target

--- a/assets/hyprpolkitagent-service.in
+++ b/assets/hyprpolkitagent-service.in
@@ -9,3 +9,6 @@ ExecStart=@LIBEXECDIR@/hyprpolkitagent
 Slice=session.slice
 TimeoutStopSec=5sec
 Restart=on-failure
+
+ [Install]
+ WantedBy=graphical-session.target


### PR DESCRIPTION
Add  `[Install]  WantedBy=graphical-session.target`, so the service could be enabled on startup. Useful for the people, who start hyprland as a systemd service.