### PR TITLE
Fix: Resolve deprecated QML syntax in main.qml

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -80,10 +80,10 @@ ApplicationWindow {
 
                 Connections {
                     target: hpa
-                    onFocusField: () => {
+                    function onFocusField() {
                         passwordField.focus = true;
                     }
-                    onBlockInput: (block) => {
+                    function onBlockInput(block) {
                         passwordField.readOnly = block;
                         if (!block) {
                             passwordField.focus = true;
@@ -105,7 +105,7 @@ ApplicationWindow {
 
                 Connections {
                     target: hpa
-                    onSetErrorString: (e) => {
+                    function onSetErrorString(e) {
                         errorLabel.text = e;
                     }
                 }


### PR DESCRIPTION
```sh
qrc:/qt/qml/hpa/qml/main.qml:97:17: QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead function onFoo(<arguments>) { ... }
```

This PR addresses deprecated usage of Connections in main.qml where implicit onFoo properties were used. The fix applies the recommended syntax for defining these connections as proper functions.