### PR TITLE
core: Require KDE only when running in KDE

### DIFF
--- a/src/core/Agent.cpp
+++ b/src/core/Agent.cpp
@@ -61,7 +61,7 @@ void CAgent::initAuthPrompt() {
 
     authState.qmlIntegration = new CQMLIntegration();
 
-    if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE"))
+    if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE") && !qEnvironmentVariableIsEmpty("KDE_FULL_SESSION"))
         QQuickStyle::setStyle("org.kde.desktop");
 
     authState.qmlEngine = new QQmlApplicationEngine();


### PR DESCRIPTION
KDE style might not be available everywhere. Better to depend on default style and allow users to override it with style settings.