### PR TITLE
dbus: add proper ini-type config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ include(GNUInstallDirs)
 
 set(LIBEXECDIR ${CMAKE_INSTALL_FULL_LIBEXECDIR})
 configure_file(assets/hyprpolkitagent-service.in hyprpolkitagent.service @ONLY)
+configure_file(assets/hyprpolkitagent-dbus.in hyprpolkitagent-dbus.service @ONLY)
 
-install(TARGETS hyprpolkitagent DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+install(TARGETS hyprpolkitagent 
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
 install(FILES ${CMAKE_BINARY_DIR}/hyprpolkitagent.service
         DESTINATION "lib/systemd/user")
+install(FILES ${CMAKE_BINARY_DIR}/hyprpolkitagent-dbus.service
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services
+        RENAME hyprpolkitagent.service)

--- a/assets/hyprpolkitagent-dbus.in
+++ b/assets/hyprpolkitagent-dbus.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=hyprpolkitagent
+Exec=@LIBEXECDIR@/hyprpolkitagent
+SystemdService=hyprpolkitagent.service


### PR DESCRIPTION
Should fix issue #21 

I thought that it would be cleaner to add an asset file specific to D-Bus and IMHO it's best practice to explicitly specify the destination paths on CMake to avoid ambiguity and ensure correct installation paths. 

Let me know if you feel like we should otherwise mangle the original `hyprpolkitagent-service.in` into two files.