### PR TITLE
Rename service-file to 'org.hyprland.hyprpolkitagent.service'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,4 +58,4 @@ install(FILES ${CMAKE_BINARY_DIR}/hyprpolkitagent.service
         DESTINATION "lib/systemd/user")
 install(FILES ${CMAKE_BINARY_DIR}/hyprpolkitagent-dbus.service
         DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services
-        RENAME hyprpolkitagent.service)
+        RENAME org.hyprland.hyprpolkitagent.service)


### PR DESCRIPTION
I don't really have much experience with this, but looking at the .service-files, the naming convention seemed to be using the same as the name of the defined service.

See output from my `/usr/share/dbus-1/services`:
```bash
.
├── ca.desrt.dconf.service
├── hyprpolkitagent.service
├── org.a11y.Bus.service
├── org.blueman.Applet.service
├── org.blueman.Manager.service
├── org.erikreider.swaync.service
├── org.flatpak.Authenticator.Oci.service
├── org.freedesktop.FileManager1.service
├── org.freedesktop.Flatpak.service
├── org.freedesktop.impl.portal.desktop.gtk.service
├── org.freedesktop.impl.portal.desktop.hyprland.service
├── org.freedesktop.impl.portal.PermissionStore.service
├── org.freedesktop.impl.portal.Secret.service
├── org.freedesktop.LocalSearch3.Control.service
├── org.freedesktop.LocalSearch3.service
├── org.freedesktop.LocalSearch3.Writeback.service
├── org.freedesktop.portal.Desktop.service
```

From what I understand, the name of the file shouldn't matter, so it is more of a cosmetic change. Tested it locally and it seems to work. I don't really know how or if it is necessary to test anymore.

I guess this would close #34.