### PR TITLE
flake.lock: bump hyprtoolkit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780390156,
-        "narHash": "sha256-sCQPtbqmUfb1/x+GIwFw1E4WPMXAW93KRhhMYfyZ9JI=",
+        "lastModified": 1780496045,
+        "narHash": "sha256-uqg11TIA0aEqe76NyaKjE+8paw/ld0oHROGCSt4FuU4=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "07b8d948e350d8be01b0f8616355d6c20110180c",
+        "rev": "a0342843294bf3257188be495874438c041eb343",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
bumps the `hyprtoolkit` flake input from `07b8d94` (#86, eye icon hover affordance) to `a034284`, picking up hyprwm/hyprtoolkit#88 which fixes single-line selection vertical centering. the password field's selection highlight was sitting at the `pango` layout top while the glyphs are `VCENTER`-offset, so the highlight box drew above the asterisks. with #88 the selection now lands on the glyphs.

hyprwm/hyprtoolkit#87 (button ellipsize) and #90 (test pinning) ride along, neither changes anything in this agent.

verified locally:
- `nix build` succeeds end to end against the new lock
- hyprtoolkit's `Element.textboxSingleLineSelectionVCentered` unit test passes
- rebuilt agent against installed toolkit, ran `pkexec`, selected the password with `Ctrl+A`, highlight now aligns with the glyphs (both masked and unmasked via the eye toggle)