### PR TITLE
ui: inhibit compositor shortcuts while the auth dialog is focused

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781290677,
-        "narHash": "sha256-8UXZuehMWYbx/ycuY+jziq8nU5l+Tj52HLpHQUh9YQk=",
+        "lastModified": 1783251381,
+        "narHash": "sha256-GKvnIib7lfKh59qpl8gdSXZ/uHnpzaGcWOtKNr3sRAM=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "1e462f851e44c47bcdc7ab4f92776ed93a05df55",
+        "rev": "ffb0d2baa26f4675db72b3ecafdb838a241b2291",
         "type": "github"
       },
       "original": {

--- a/src/ui/Dialog.cpp
+++ b/src/ui/Dialog.cpp
@@ -152,6 +152,10 @@ void CDialog::build() {
                    ->maxSize({600.0, targetHeight})
                    ->appTitle("Authentication Required")
                    ->appClass("hyprpolkitagent")
+                   // inhibit compositor keybinds while the prompt is focused so a focus-cycle
+                   // bind can't move keyboard off the dialog mid-password. no-ops where the
+                   // compositor doesn't advertise the manager.
+                   ->inhibitShortcuts(true)
                    ->commence();
 
     m_closeListener = m_window->m_events.closeRequest.listen([] { g_pAgent->cancel(); });


### PR DESCRIPTION
request a keyboard shortcuts inhibitor on the dialog toplevel so the compositor stops firing its global keybinds while the prompt has focus. this keeps a window cycle bind (hl.dsp.window.cycle_next/prev) from pulling keyboard off the prompt while a password is being typed, and unlike a layer surface the dialog keeps its border and window rules.

uses the inhibitShortcuts option added in hyprwm/hyprtoolkit#101. refs #37.