### PR TITLE
ui: hide the password field while a fingerprint or key is pending

### DIFF
--- a/src/ui/Dialog.cpp
+++ b/src/ui/Dialog.cpp
@@ -55,6 +55,11 @@ void CDialog::setPrompt(const std::string& text, bool echo) {
     if (newPrompt.empty())
         newPrompt = "Password";
 
+    // a real password prompt: pam wants typed input now, so reveal the field and button
+    // if a preceding cue had hidden them. no-op when already visible (password-only auth).
+    m_sawPasswordPrompt = true;
+    showPasswordField(true);
+
     // initial prompt arrives after build() and would clobber the first keystroke
     const bool clean = m_currentPassword.empty() && newPrompt == m_promptText && echo == m_promptEcho;
 
@@ -116,7 +121,28 @@ void CDialog::showStatus(CSharedPointer<IElement>& wrap, bool& shown, bool show)
     }
 }
 
+void CDialog::showPasswordField(bool show) {
+    if (show == m_passwordVisible || !m_passwordWrap)
+        return;
+    m_passwordVisible = show;
+    if (show) {
+        m_passwordWrap->addChild(m_passwordField);
+        if (m_btnRow && m_authButton)
+            m_btnRow->addChild(m_authButton);
+        m_passwordField->focus();
+    } else {
+        m_passwordWrap->removeChild(m_passwordField);
+        if (m_btnRow && m_authButton)
+            m_btnRow->removeChild(m_authButton);
+    }
+}
+
 void CDialog::setInfo(const std::string& text) {
+    // a pam cue (fingerprint reader, security key) that arrives before any password
+    // prompt means pam is not asking for a password yet. hide the field until it does,
+    // and reveal it only if pam falls back to a password prompt. matches polkit-gnome.
+    if (!text.empty() && !m_sawPasswordPrompt)
+        showPasswordField(false);
     if (m_infoLabel)
         m_infoLabel->setText(std::string{text});
     showStatus(m_infoWrap, m_infoShown, !text.empty());
@@ -295,6 +321,9 @@ void CDialog::build() {
         buildPasswordField();
         wrap->addChild(m_passwordField);
         outer->addChild(wrap);
+        // kept as a member so the field can be pulled out and put back while a
+        // fingerprint or security key is pending (see showPasswordField).
+        m_passwordWrap = wrap;
     }
 
     // wraps are only attached when their label has text, so empty labels reserve no space
@@ -341,6 +370,7 @@ void CDialog::build() {
                            ->commence();
         btnRow->addChild(m_authButton);
         outer->addChild(btnRow);
+        m_btnRow = btnRow;
     }
 
     std::vector<std::pair<std::string, std::string>> fields;

--- a/src/ui/Dialog.hpp
+++ b/src/ui/Dialog.hpp
@@ -30,6 +30,7 @@ class CDialog {
     void                                                            build();
     void                                                            buildPasswordField();
     void                                                            showStatus(Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>& wrap, bool& shown, bool show);
+    void                                                            showPasswordField(bool show);
 
     Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IBackend>        m_backend;
     Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IWindow>         m_window;
@@ -46,6 +47,8 @@ class CDialog {
     Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>        m_capsWrap;
     Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>        m_errWrap;
     Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>        m_infoWrap;
+    Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>        m_passwordWrap;
+    Hyprutils::Memory::CSharedPointer<Hyprtoolkit::IElement>        m_btnRow;
 
     Hyprutils::Signal::CHyprSignalListener                          m_closeListener;
     Hyprutils::Signal::CHyprSignalListener                          m_keyListener;
@@ -59,5 +62,7 @@ class CDialog {
     bool                                                            m_capsShown      = false;
     bool                                                            m_errShown       = false;
     bool                                                            m_infoShown      = false;
+    bool                                                            m_sawPasswordPrompt = false;
+    bool                                                            m_passwordVisible   = true;
     std::string                                                     m_promptText     = "Password";
 };


### PR DESCRIPTION
follow the pam conversation instead of always showing a password box. a PAM_TEXT_INFO cue that arrives before any password prompt (a fingerprint reader or a security key) now hides the password field and the authenticate button and shows only the cue and cancel, the way polkit gnome does. the field comes back the moment pam sends an actual password prompt, so password only auth is unchanged.

tested password only here (field shows, and a post prompt info message does not hide it). the biometric path was exercised with a synthetic pre prompt cue: the field and authenticate button hide, only the cue and cancel remain. i don't have a fingerprint reader or a security key, so pam_fprintd / pam_u2f were not run. if someone with hardware can confirm the cue arrives as PAM_TEXT_INFO before the password prompt, that closes it.

refs #24, #26.